### PR TITLE
Only store unwrapped content

### DIFF
--- a/Tests/SwiftJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftJSONTests/PerformanceTests.swift
@@ -44,7 +44,7 @@ class PerformanceTests: XCTestCase {
 
     func testInitPerformance() {
         self.measure {
-            for _ in 1...100 {
+            for _ in 1...1_000 {
                 guard let json = try? JSON(data: self.testData) else {
                     XCTFail("Unable to parse testData")
                     return
@@ -60,7 +60,7 @@ class PerformanceTests: XCTestCase {
             return
         }
         self.measure {
-            for _ in 1...100_000 {
+            for _ in 1...1_000 {
                 let object: Any? = json.object
                 XCTAssertTrue(object != nil)
             }
@@ -105,7 +105,7 @@ class PerformanceTests: XCTestCase {
             return
         }
         self.measure {
-            for _ in 1...100 {
+            for _ in 1...1_000 {
                 autoreleasepool {
                     let string = json.rawString()
                     XCTAssertTrue(string != nil)
@@ -150,9 +150,49 @@ class PerformanceTests: XCTestCase {
             ]
         
         self.measure {
-            (1...10_000).forEach { _ in
+            (1...1_000).forEach { _ in
                 let resultValue = dictionary["one"]["two"]["three"]["four"]["five"]
                 XCTAssertTrue(resultValue == "result")
+            }
+        }
+    }
+
+    func testLongNestedArrayPerformance() {
+        let nestedArray = (0..<1_000).map { i in
+            [
+                "one": [
+                    "two": [
+                        "three": [
+                            "four": [
+                                "five": i,
+                            ],
+                        ],
+                    ],
+                ],
+                "two": [
+                    "three": [
+                        "four": [
+                            "five": i,
+                        ],
+                    ],
+                ],
+                "three": [
+                    "four": [
+                        "five": i,
+                    ],
+                ],
+                "four": [
+                    "five": i,
+                ],
+                "five": i,
+            ]
+        }
+        let dictionary: JSON = ["list": nestedArray]
+
+        self.measure {
+            nestedArray.indices.forEach { index in
+                let resultValue = dictionary["list"][index]["five"]
+                XCTAssertEqual(resultValue.int, index)
             }
         }
     }


### PR DESCRIPTION
This PR improves how `JSON` handles its content. Previously the content was _unwrapped_ when initializing a new `JSON` value. This was done to support nesting values of type `JSON` into e.g. dictionaries. However, when _unwrapping_ a nested `JSON` value its underlying raw value (i.e. `object`) was extracted, loosing all information previously gather about its content. This approach only improved performance when working with the raw underlying values of `JSON`, e.g. when using `object`, `arrayObject` or `dictionaryObject`, which should be the exception.

With this PR, the `Content` is strongly typed to only store raw primitives or array/dictionaries of `Content` values. This requires resolving the whole JSON upon initializing a new `JSON` value once. All subsequent accesses to any of its values (e.g. via subscript) are super cheap now, as we can just re-use the previously extracted content value. Resolving the JSON upon initialization is also cheaper now when working with nested `JSON` values, as we can just re-use their content as well.

To see the performance improvements this PR brings you can copy the new performance test `testLongNestedArrayPerformance` to a checkout of `master` to get a baseline timing value for comparison.

Note on the code style: I tried to stay as close as possible to the code style of the upstream repository and only apply minimal fixes.