### PR TITLE
Fix resolving of optional values

### DIFF
--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -301,14 +301,16 @@ private func resolveContent(for jsonObject: Any) -> Content {
         return .dictionary(dictionary.mapValues(resolveContent))
     case let array as [Any]:
         return .array(array.map(resolveContent))
+    case let string as String:
+        return .string(string)
+    case let number as NSNumber:
+            return number.isBool ? .bool(number.boolValue) : .number(number)
     case nil:
         return .null
     case is NSNull:
         return .null
-    case let string as String:
-        return .string(string)
-    case let number as NSNumber:
-        return number.isBool ? .bool(number.boolValue) : .number(number)
+    case is AnyOptional:
+        return .null
     default:
         return .unknown
     }
@@ -1460,3 +1462,7 @@ extension JSON: Codable {
         }
     }
 }
+
+fileprivate protocol AnyOptional {}
+
+extension Optional: AnyOptional {}

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -309,7 +309,7 @@ private func resolveContent(for jsonObject: Any) -> Content {
         return .null
     case is NSNull:
         return .null
-    case is AnyOptional:
+    case let optionalValue as AnyOptional where optionalValue.isNil:
         return .null
     default:
         return .unknown
@@ -1463,6 +1463,17 @@ extension JSON: Codable {
     }
 }
 
-fileprivate protocol AnyOptional {}
+fileprivate protocol AnyOptional {
+    var isNil: Bool { get }
+}
 
-extension Optional: AnyOptional {}
+extension Optional: AnyOptional {
+    fileprivate var isNil: Bool {
+        switch self {
+            case .some:
+                return false
+            case .none:
+                return true
+        }
+    }
+}

--- a/Source/SwiftyJSON/SwiftyJSON.swift
+++ b/Source/SwiftyJSON/SwiftyJSON.swift
@@ -304,7 +304,7 @@ private func resolveContent(for jsonObject: Any) -> Content {
     case let string as String:
         return .string(string)
     case let number as NSNumber:
-            return number.isBool ? .bool(number.boolValue) : .number(number)
+        return number.isBool ? .bool(number.boolValue) : .number(number)
     case nil:
         return .null
     case is NSNull:

--- a/Tests/SwiftJSONTests/BaseTests.swift
+++ b/Tests/SwiftJSONTests/BaseTests.swift
@@ -274,4 +274,11 @@ class BaseTests: XCTestCase {
             // everything is OK
         }
     }
+
+    func testOptionalResolving() {
+        let nilString: String? = nil
+        let json = JSON(nilString as Any)
+
+        XCTAssertEqual(json.type, .null)
+    }
 }

--- a/Tests/SwiftJSONTests/BaseTests.swift
+++ b/Tests/SwiftJSONTests/BaseTests.swift
@@ -276,9 +276,12 @@ class BaseTests: XCTestCase {
     }
 
     func testOptionalResolving() {
-        let nilString: String? = nil
-        let json = JSON(nilString as Any)
+        let nilOptionalString: String? = nil
+        let nonNilOptionalString: String? = "foo"
+        let nonNilOptionalTestCase: XCTestCase? = self
 
-        XCTAssertEqual(json.type, .null)
+        XCTAssertEqual(JSON(nilOptionalString as Any).type, .null)
+        XCTAssertEqual(JSON(nonNilOptionalString as Any).type, .string)
+        XCTAssertEqual(JSON(nonNilOptionalTestCase as Any).type, .unknown)
     }
 }


### PR DESCRIPTION
In #2 I changed the way how JSON values are resolved upon initialization. This introduced a small regression for an edge case when a `JSON` value was initialized from a _literal_ containing an optional value that is actually `nil`:
```swift
let nilString: String? = nil
let json = JSON(nilString as Any)
```
In this case the value has an actual type of `String?`, even though it is cast to `Any`. This surprisingly does not match `nil` when resolving the value, resulting in a `content` of `.unknown` rather than `.null`.

This PR fixes that by resolving all values of an `Optional` type to `.null` as a fallback.