### PR TITLE
Fix resolving of nested `Data` containing JSON

### DIFF
--- a/Tests/SwiftJSONTests/BaseTests.swift
+++ b/Tests/SwiftJSONTests/BaseTests.swift
@@ -284,4 +284,18 @@ class BaseTests: XCTestCase {
         XCTAssertEqual(JSON(nonNilOptionalString as Any).type, .string)
         XCTAssertEqual(JSON(nonNilOptionalTestCase as Any).type, .unknown)
     }
+
+    func testNestedDataResolving() {
+        let json = JSON([
+            "root": #"{"foo": "bar"}"#.data(using: .utf8)!
+        ])
+
+        XCTAssertEqual(json["root"]["foo"].string, "bar")
+
+        let invalidJson = JSON([
+            "root": #"baz"#.data(using: .utf8)!
+        ])
+
+        XCTAssertEqual(invalidJson.error, .invalidJSON)
+    }
 }


### PR DESCRIPTION
Before the performance refactoring added via #2 it was possible to decode a JSON value that contained nested `Data` values, which themselves contained valid JSON:
```switt
let json = JSON([
    "root": #"{"foo": "bar"}"#.data(using: .utf8)!
])
```

This is an edge case, since it can only happen if the JSON content was constructed in code or at runtime (not when decoding e.g. from a `String`), but we use this feature ourselves.

#2 broke that feature. This PR fixes it.